### PR TITLE
Fix coldbox, testbox mapping paths in tests application

### DIFF
--- a/app/views/main/index.cfm
+++ b/app/views/main/index.cfm
@@ -116,7 +116,7 @@
 
 					<div class="d-grid gap-2 d-sm-flex justify-content-sm-center">
 						<a
-							href="#getSetting( "appMapping" )#/tests/index.cfm"
+							href="/tests/index.cfm"
 							class="btn btn-dark btn-lg"
 							role="button"
 							target="_blank"
@@ -126,7 +126,7 @@
 						</a>
 
 						<a
-							href="#getSetting( "appMapping" )#/tests/runner.cfm"
+							href="/tests/runner.cfm"
 							class="btn btn-dark btn-lg"
 							role="button"
 							target="_blank"

--- a/tests/Application.cfc
+++ b/tests/Application.cfc
@@ -19,13 +19,13 @@ component{
 	// Map back to its root
 	rootPath = REReplaceNoCase( this.mappings[ "/tests" ], "tests(\\|/)", "" );
 	// App Mappings
-	this.mappings[ "/app" ] =  rootPath & "app";
-	this.mappings[ "/coldbox" ] = rootPath & "coldbox";
-	this.mappings[ "/lib" ] = rootPath & "lib";
-	this.mappings[ "/logs" ] = rootPath & "logs";
+	this.mappings[ "/app" ]     = rootPath & "app";
+	this.mappings[ "/lib" ]     = rootPath & "lib";
+	this.mappings[ "/logs" ]    = rootPath & "logs";
 	this.mappings[ "/modules" ] = rootPath & "modules";
-	this.mappings[ "/testbox" ] = rootPath & "testbox";
-	this.mappings[ "/root" ] = rootPath & "public";
+	this.mappings[ "/root" ]    = rootPath & "public";
+	this.mappings[ "/coldbox" ] = this.mappings[ "/lib" ] & "/coldbox";
+	this.mappings[ "/testbox" ] = this.mappings[ "/lib" ] & "/testbox";
 
 	public boolean function onRequestStart( targetPage ){
 		// Set a high timeout for long running tests

--- a/tests/Application.cfc
+++ b/tests/Application.cfc
@@ -31,7 +31,7 @@ component{
 		// Set a high timeout for long running tests
 		setting requestTimeout="9999";
 		// New ColdBox Virtual Application Starter
-		request.coldBoxVirtualApp = new coldbox.system.testing.VirtualApp( appMapping = "/cbTestHarness" );
+		request.coldBoxVirtualApp = new coldbox.system.testing.VirtualApp( appMapping = "/app" );
 
 		// If hitting the runner or specs, prep our virtual app and database
 		if ( getBaseTemplatePath().replace( expandPath( "/tests" ), "" ).reFindNoCase( "(runner|specs)" ) ) {


### PR DESCRIPTION
The tests application needs to point to the new location of the `coldbox` and `testbox` libs. For this app template, that's in the `lib/coldbox` and `lib/testbox` directories, respectively.