### PR TITLE
Update cbdebugger version to support ColdBox 7

### DIFF
--- a/box.json
+++ b/box.json
@@ -19,7 +19,7 @@
 	],
     "dependencies":{
         "coldbox":"^7.0.0",
-        "cbdebugger":"^3.2.0+5"
+        "cbdebugger":"^4.3.0+5"
     },
     "devDependencies":{
         "testbox":"^5.0.0",


### PR DESCRIPTION
# Description

The version for the dependency of `cbdebugger` was changed to `^4.3.0+5` to support ColdBox 7. Without this fix, an error would occur during the `postProcess` interceptor, appearing at the bottom of a rendered page.

However, I'm unable to confirm that this does not cause issues elsewhere. I'm not yet familiar with how to set up tests with ColdBox. All I know is that I could not run the template as is without updating the dependency to the next major version.

## Issues

Closes #6 

## Type of change

- [x] Bug Fix

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [ ] (N/A) I have commented my code, particularly in hard-to-understand areas
- [ ] (N/A?) I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
