### PR TITLE
Add Lucee compatibility

### DIFF
--- a/server.json
+++ b/server.json
@@ -21,7 +21,8 @@
     "cfconfig":{
         "file":"./.cfconfig.json"
     },
-    "scripts":{
-        "onServerInstall":"install bx-esapi,bx-compat-cfml --noSave"
-    }
+    "onServerInstall":[
+        "assertEqual \\${serverinfo.engineName} boxlang && install bx-esapi,bx-compat-cfml; exit 0",
+        "assertEqual \\${serverinfo.engineName} lucee && cfconfig cfmapping save /tests {web-root-directory}/../tests; exit 0"
+    ]
 }


### PR DESCRIPTION
Add server mapping for Lucee testbox compatiblity. Install boxlang modules only on BNL instances.

# Description

Two changes made to `server.json`:

1. Change the first install script to only install boxlang modules if the server instance is boxlang. Otherwise, the template would install boxlang modules in the Public folder on non-boxlang installs.
2. Adding Lucee compatibility for Testbox requires a server level mapping for the `/tests' folder on Lucee instances.

**Please note that all PRs must have tests attached to them**

IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

## Issues

[All PRs must have an accompanied issue. Please make sure you created it and linked it here.](https://github.com/coldbox-templates/modern/issues/11)

## Type of change

Please delete options that are not relevant.

- [ ] Bug Fix
- [x] Improvement
- [ ] New Feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
