### PR TITLE
Address modules folder location and mapping

### DIFF
--- a/box.json
+++ b/box.json
@@ -33,6 +33,9 @@
         "coldbox":"lib/coldbox/",
         "testbox":"lib/testbox/"
     },
+    "installPathConventions":{
+        "modules":"lib/modules"
+    },
     "scripts":{
         "postPublish":"!git push origin --tags",
         "postInstall":"pathExists .env || cp .env.example .env",

--- a/public/Application.cfc
+++ b/public/Application.cfc
@@ -33,7 +33,7 @@ component {
 	this.mappings[ "/public" ]     = _publicRoot;
 	this.mappings[ "/app" ]     = _root & "app";
 	this.mappings[ "/coldbox" ]     = _root & "lib/coldbox";
-	this.mappings[ "/modules" ]     = _root & "modules";
+	this.mappings[ "/modules" ]     = _root & "lib/modules";
 
 	/**
 	 * --------------------------------------------------------------------------


### PR DESCRIPTION


# Description

If docs are correct,then the Commandbox managed modules folder should be in the `lib` folder (along with Coldbox and Testbox). Ths requires a few changes:

1. Change the folder structure to point there
2. Add a `installPathConventions` directive in `box.json` to point new module installs there
3. Address the discrepency in the `/modules` cfmapping between the `Applicationn.cfc` files in the `Public` folder and the `tests` folder.

**Please note that all PRs must have tests attached to them**

IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

## Issues

https://github.com/coldbox-templates/modern/issues/13

## Type of change

Please delete options that are not relevant.

- [x] Bug Fix
- [ ] Improvement
- [ ] New Feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
